### PR TITLE
feat: Add Docker setup, improved startup script, and Anthropic LLM support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 # Database Configuration
 DATABASE_URL=postgres://synchronicity:synchronicity_dev_pass@localhost:5436/synchronicity_engine
 
+# Docker PostgreSQL Configuration (used by docker-compose.yml)
+POSTGRES_USER=synchronicity
+POSTGRES_PASSWORD=synchronicity_dev_pass
+POSTGRES_DB=synchronicity_engine
+
 # API Configuration
 API_VERSION=v1 # API version prefix (e.g., /api/v1/...)
 PORT=3001 # Backend server port
@@ -16,5 +21,6 @@ OPENAI_MODEL_NAME=gpt-4.1-mini # Latest: gpt-4.1-mini, gpt-4.1-nano, or gpt-4.1
 
 # --- LangChain Provider Settings ---
 LANGCHAIN_PROVIDER=openai # "openai" or "anthropic"
+LANGCHAIN_TEMPERATURE=0.7 # Temperature for LLM responses (0.0-1.0, higher = more creative)
 # ANTHROPIC_API_KEY=
 # ANTHROPIC_MODEL_NAME=claude-sonnet-4-5 # Options: claude-sonnet-4-5 (best), claude-haiku-4-5 (fast/cheap), claude-opus-4-1 (agentic)

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ DATABASE_URL=postgres://user:pass@host:5432/dbname
 # API Configuration
 API_VERSION=v1 # API version prefix (e.g., /api/v1/...)
 PORT=3001 # Backend server port
-HOST=0.0.0.0 # Backend server host
+HOST=127.0.0.1 # Backend server host (use 0.0.0.0 to expose on network)
 
 # LLM Adapters:
 LLM_PROVIDER=mock # "mock", "openai", or "langchain"

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,12 @@
-# For Postgres dev & prod:
+# Database Configuration
 DATABASE_URL=postgres://user:pass@host:5432/dbname
 
-# For LLM Adapters:
+# API Configuration
+API_VERSION=v1 # API version prefix (e.g., /api/v1/...)
+PORT=3001 # Backend server port
+HOST=0.0.0.0 # Backend server host
+
+# LLM Adapters:
 LLM_PROVIDER=mock # "mock", "openai", or "langchain"
 STRICT_JSON=false
 

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Database Configuration
-DATABASE_URL=postgres://user:pass@host:5432/dbname
+DATABASE_URL=postgres://synchronicity:synchronicity_dev_pass@localhost:5436/synchronicity_engine
 
 # API Configuration
 API_VERSION=v1 # API version prefix (e.g., /api/v1/...)

--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,9 @@ STRICT_JSON=false
 
 # --- Direct OpenAI Provider Settings ---
 OPENAI_API_KEY=
-OPENAI_MODEL_NAME=gpt-4-turbo
+OPENAI_MODEL_NAME=gpt-4.1-mini # Latest: gpt-4.1-mini, gpt-4.1-nano, or gpt-4.1
 
 # --- LangChain Provider Settings ---
 LANGCHAIN_PROVIDER=openai # "openai" or "anthropic"
 # ANTHROPIC_API_KEY=
+# ANTHROPIC_MODEL_NAME=claude-sonnet-4-5 # Options: claude-sonnet-4-5 (best), claude-haiku-4-5 (fast/cheap), claude-opus-4-1 (agentic)

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 build/
 coverage/
+tmp/
 .vscode/
 .DS_Store
 .env

--- a/SynchronicityEngine.code-workspace
+++ b/SynchronicityEngine.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -70,7 +70,7 @@ server.post(`${API_PREFIX}/sessions/:id/actions`, async (request, reply) => {
 });
 
 const port = Number(process.env.PORT ?? 3001);
-const host = process.env.HOST ?? '0.0.0.0';
+const host = process.env.HOST ?? '127.0.0.1';
 
 const start = async (): Promise<void> => {
   try {

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -20,6 +20,10 @@ import aiRoutes from './routes/ai.js';
 
 const server = Fastify({ logger: true });
 
+// Configuration
+const API_VERSION = process.env.API_VERSION ?? 'v1';
+const API_PREFIX = `/api/${API_VERSION}`;
+
 // The engine now conforms to the port interfaces
 const engine: EngineCommandPort & EngineQueryPort = createDefaultEngine();
 
@@ -31,24 +35,24 @@ const logSink: ILogSink = createNdjsonLogger('var/logs', 'backend');
 await server.register(cors, { origin: true });
 
 server.register(storage);
-server.register(promptRoutes, { prefix: '/api/v1/prompt', logSink, traceSink });
+server.register(promptRoutes, { prefix: `${API_PREFIX}/prompt`, logSink, traceSink });
 server.register(logRoutes, { logSink });
-server.register(incarnationRoutes, { prefix: '/api/v1' });
-server.register(aiRoutes, { prefix: '/api/v1/ai' });
+server.register(incarnationRoutes, { prefix: API_PREFIX });
+server.register(aiRoutes, { prefix: `${API_PREFIX}/ai` });
 
 server.get('/health', () => {
   return { status: 'ok' };
 });
 
 // Refactored to use the snapshot query port and the v1 DTO
-server.get('/api/v1/sessions/:id', async (request): Promise<EngineSnapshotV1> => {
+server.get(`${API_PREFIX}/sessions/:id`, async (request): Promise<EngineSnapshotV1> => {
   const { id } = request.params as { id: string };
   const snapshot = await engine.snapshot(id);
   return snapshot;
 });
 
 // Refactored to use the act command port
-server.post('/api/v1/sessions/:id/actions', async (request, reply) => {
+server.post(`${API_PREFIX}/sessions/:id/actions`, async (request, reply) => {
   const { id } = request.params as { id: string };
   const body = request.body as { actionId?: string };
   if (!body?.actionId) {

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,0 +1,3 @@
+# Frontend API Configuration
+VITE_API_URL=http://localhost:3001
+VITE_API_VERSION=v1

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -20,12 +20,12 @@ const handleResponse = async <T>(response: Response): Promise<T> => {
 };
 
 export const fetchSnapshot = async (sessionId: string): Promise<EngineSnapshot> => {
-  const response = await fetch(`${API_URL}/api/sessions/${sessionId}`);
+  const response = await fetch(`${API_URL}/api/v1/sessions/${sessionId}`);
   return handleResponse<EngineSnapshot>(response);
 };
 
 export const submitAction = async (sessionId: string, actionId: string): Promise<EngineActionResult> => {
-  const response = await fetch(`${API_URL}/api/sessions/${sessionId}/actions`, {
+  const response = await fetch(`${API_URL}/api/v1/sessions/${sessionId}/actions`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ actionId }),

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -1,5 +1,6 @@
 import type { EngineActionResult, EngineSnapshot } from '@synchronicity/engine';
 
+// API Configuration
 const extractEnvApiUrl = (): string | undefined => {
   const value = import.meta.env.VITE_API_URL;
   if (typeof value === 'string' && value.trim().length > 0) {
@@ -9,6 +10,13 @@ const extractEnvApiUrl = (): string | undefined => {
 };
 
 const API_URL = extractEnvApiUrl() ?? 'http://localhost:3001';
+const API_VERSION = import.meta.env.VITE_API_VERSION ?? 'v1';
+
+// API Endpoints
+const ENDPOINTS = {
+  session: (sessionId: string) => `${API_URL}/api/${API_VERSION}/sessions/${sessionId}`,
+  sessionActions: (sessionId: string) => `${API_URL}/api/${API_VERSION}/sessions/${sessionId}/actions`,
+} as const;
 
 const handleResponse = async <T>(response: Response): Promise<T> => {
   if (!response.ok) {
@@ -20,12 +28,12 @@ const handleResponse = async <T>(response: Response): Promise<T> => {
 };
 
 export const fetchSnapshot = async (sessionId: string): Promise<EngineSnapshot> => {
-  const response = await fetch(`${API_URL}/api/v1/sessions/${sessionId}`);
+  const response = await fetch(ENDPOINTS.session(sessionId));
   return handleResponse<EngineSnapshot>(response);
 };
 
 export const submitAction = async (sessionId: string, actionId: string): Promise<EngineActionResult> => {
-  const response = await fetch(`${API_URL}/api/v1/sessions/${sessionId}/actions`, {
+  const response = await fetch(ENDPOINTS.sessionActions(sessionId), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ actionId }),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: synchronicity-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: synchronicity
+      POSTGRES_PASSWORD: synchronicity_dev_pass
+      POSTGRES_DB: synchronicity_engine
+    ports:
+      - "5436:5432"  # Using 5436 to avoid conflicts with other projects
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U synchronicity"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,15 @@ services:
     container_name: synchronicity-db
     restart: unless-stopped
     environment:
-      POSTGRES_USER: synchronicity
-      POSTGRES_PASSWORD: synchronicity_dev_pass
-      POSTGRES_DB: synchronicity_engine
+      POSTGRES_USER: ${POSTGRES_USER:-synchronicity}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-synchronicity_dev_pass}
+      POSTGRES_DB: ${POSTGRES_DB:-synchronicity_engine}
     ports:
       - "5436:5432"  # Using 5436 to avoid conflicts with other projects
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U synchronicity"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-synchronicity}"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/package-lock.json
+++ b/package-lock.json
@@ -2194,6 +2194,41 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@langchain/anthropic": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-1.0.0.tgz",
+      "integrity": "sha512-Lud/FrkFmXMYW5R9y0FC+RGdgjBBVQ2JAnG3A8E1I4+sqv5JgJttw3HKRpFkyBUSyacs6LMfSn5dbJ6TT9nMiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.65.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.0.0"
+      }
+    },
+    "node_modules/@langchain/anthropic/node_modules/@anthropic-ai/sdk": {
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.65.0.tgz",
+      "integrity": "sha512-zIdPOcrCVEI8t3Di40nH4z9EoeyGZfXbYSvWdDLsB/KkaSYMnEgC7gmcgWu83g2NTn1ZTpbMvpdttWDGGIk6zw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@langchain/core": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.0.2.tgz",
@@ -10561,6 +10596,7 @@
       "name": "@synchronicity/prompt-kit",
       "version": "0.0.1",
       "dependencies": {
+        "@langchain/anthropic": "^1.0.0",
         "@langchain/core": "^1.0.2",
         "@langchain/openai": "^1.0.0",
         "langchain": "^0.0.184",

--- a/packages/persistence/src/config.ts
+++ b/packages/persistence/src/config.ts
@@ -1,0 +1,26 @@
+import { config } from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+/**
+ * Load .env file from project root (../../.env relative to this package).
+ * This utility is shared across db.ts, migrate.ts, and seed.ts to avoid duplication.
+ */
+export function loadEnvFromRoot(): void {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+  const envPath = join(__dirname, '../../../.env');
+
+  config({ path: envPath });
+}
+
+/**
+ * Get DATABASE_URL from environment or throw error
+ */
+export function getDatabaseUrl(): string {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error('DATABASE_URL is not set in environment variables');
+  }
+  return url;
+}

--- a/packages/persistence/src/db.ts
+++ b/packages/persistence/src/db.ts
@@ -1,17 +1,10 @@
-import { config } from 'dotenv';
 import { drizzle } from 'drizzle-orm/node-postgres'
 import { Pool } from 'pg'
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { loadEnvFromRoot, getDatabaseUrl } from './config.js';
 
-// Load .env from project root (../../.env relative to this file)
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-config({ path: join(__dirname, '../../../.env') });
+// Load .env from project root
+loadEnvFromRoot();
+const DATABASE_URL = getDatabaseUrl();
 
-if (!process.env.DATABASE_URL) {
-throw new Error('DATABASE_URL is not set')
-}
-
-const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+const pool = new Pool({ connectionString: DATABASE_URL })
 export const db = drizzle(pool);

--- a/packages/persistence/src/db.ts
+++ b/packages/persistence/src/db.ts
@@ -1,6 +1,13 @@
-import 'dotenv/config'
+import { config } from 'dotenv';
 import { drizzle } from 'drizzle-orm/node-postgres'
 import { Pool } from 'pg'
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+// Load .env from project root (../../.env relative to this file)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+config({ path: join(__dirname, '../../../.env') });
 
 if (!process.env.DATABASE_URL) {
 throw new Error('DATABASE_URL is not set')

--- a/packages/persistence/src/migrate.ts
+++ b/packages/persistence/src/migrate.ts
@@ -1,7 +1,14 @@
-import 'dotenv/config';
+import { config } from 'dotenv';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import pg from 'pg';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+// Load .env from project root (../../.env relative to this file)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+config({ path: join(__dirname, '../../../.env') });
 
 if (!process.env.DATABASE_URL) {
   throw new Error('DATABASE_URL is not set');

--- a/packages/persistence/src/migrate.ts
+++ b/packages/persistence/src/migrate.ts
@@ -1,23 +1,18 @@
-import { config } from 'dotenv';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import pg from 'pg';
 import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { dirname } from 'path';
+import { loadEnvFromRoot, getDatabaseUrl } from './config.js';
 
-// Load .env from project root (../../.env relative to this file)
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-config({ path: join(__dirname, '../../../.env') });
-
-if (!process.env.DATABASE_URL) {
-  throw new Error('DATABASE_URL is not set');
-}
+// Load .env from project root
+loadEnvFromRoot();
+const DATABASE_URL = getDatabaseUrl();
 
 // This is a bit of a hack to get around the fact that the `db` object
 // is a singleton and we need to end the connection pool after the migration.
 // We create a new pool here and pass it to the migrator.
-const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+const pool = new pg.Pool({ connectionString: DATABASE_URL });
 const migrationDb = drizzle(pool);
 
 async function main() {

--- a/packages/persistence/src/seed.ts
+++ b/packages/persistence/src/seed.ts
@@ -1,3 +1,12 @@
+import { config } from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+// Load .env from project root
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+config({ path: join(__dirname, '../../../.env') });
+
 import { createSession, startRun } from './repositories.js'
 const s = crypto.randomUUID()
 const r = crypto.randomUUID()

--- a/packages/persistence/src/seed.ts
+++ b/packages/persistence/src/seed.ts
@@ -1,11 +1,7 @@
-import { config } from 'dotenv';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { loadEnvFromRoot } from './config.js';
 
 // Load .env from project root
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-config({ path: join(__dirname, '../../../.env') });
+loadEnvFromRoot();
 
 import { createSession, startRun } from './repositories.js'
 const s = crypto.randomUUID()

--- a/packages/prompt-kit/package.json
+++ b/packages/prompt-kit/package.json
@@ -5,15 +5,27 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" },
-    "./utils": { "import": "./dist/utils/index.js", "types": "./dist/utils/index.d.ts" },
-    "./types": { "import": "./dist/types.js", "types": "./dist/types.d.ts" }
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./utils": {
+      "import": "./dist/utils/index.js",
+      "types": "./dist/utils/index.d.ts"
+    },
+    "./types": {
+      "import": "./dist/types.js",
+      "types": "./dist/types.d.ts"
+    }
   },
-  "engines": { "node": ">=20.0.0" },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
+    "@langchain/anthropic": "^1.0.0",
     "@langchain/core": "^1.0.2",
     "@langchain/openai": "^1.0.0",
     "langchain": "^0.0.184",

--- a/packages/prompt-kit/src/PromptService.ts
+++ b/packages/prompt-kit/src/PromptService.ts
@@ -1,4 +1,6 @@
 import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
 import { LawRegistry } from './LawRegistry.js';
 import { PersonaRegistry } from './PersonaRegistry.js';
 import { BeliefRenderer } from './render/BeliefRenderer.js';
@@ -8,6 +10,8 @@ import { renderGuardrails } from './render/GuardrailsComposer.js';
 import { PromptAssemblyInput, ChatAssembly } from './types.js';
 import { createSha256Hash, truncateForModel } from './utils/index.js';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 const promptsBasePath = path.join(__dirname, '..', '..', '..', 'config', 'prompts');
 const lawRegistry = new LawRegistry(promptsBasePath);
 const personaRegistry = new PersonaRegistry(promptsBasePath);

--- a/packages/prompt-kit/src/adapters/LangChainAdapter.ts
+++ b/packages/prompt-kit/src/adapters/LangChainAdapter.ts
@@ -1,4 +1,5 @@
 import { ChatOpenAI } from '@langchain/openai';
+import { ChatAnthropic } from '@langchain/anthropic';
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { EngineEventPayload, EngineEventPayloadSchema } from '../schema/event.js';
 
@@ -6,10 +7,25 @@ export async function generate(
   system: string,
   user: string
 ): Promise<EngineEventPayload> {
-  const llm = new ChatOpenAI({
-    modelName: 'gpt-4-turbo-preview',
-    apiKey: process.env.OPENAI_API_KEY,
-  });
+  const provider = process.env.LANGCHAIN_PROVIDER || 'openai';
+
+  let llm;
+
+  if (provider === 'anthropic') {
+    // Use Anthropic Claude
+    llm = new ChatAnthropic({
+      modelName: process.env.ANTHROPIC_MODEL_NAME || 'claude-sonnet-4-5',
+      apiKey: process.env.ANTHROPIC_API_KEY,
+      temperature: 0.7,
+    });
+  } else {
+    // Use OpenAI (default)
+    llm = new ChatOpenAI({
+      modelName: process.env.OPENAI_MODEL_NAME || 'gpt-4.1-mini',
+      apiKey: process.env.OPENAI_API_KEY,
+      temperature: 0.7,
+    });
+  }
 
   const structuredLLM = llm.withStructuredOutput(EngineEventPayloadSchema);
 

--- a/packages/prompt-kit/src/adapters/LangChainAdapter.ts
+++ b/packages/prompt-kit/src/adapters/LangChainAdapter.ts
@@ -8,23 +8,29 @@ export async function generate(
   user: string
 ): Promise<EngineEventPayload> {
   const provider = process.env.LANGCHAIN_PROVIDER || 'openai';
+  const temperature = parseFloat(process.env.LANGCHAIN_TEMPERATURE || '0.7');
 
   let llm;
 
-  if (provider === 'anthropic') {
-    // Use Anthropic Claude
-    llm = new ChatAnthropic({
-      modelName: process.env.ANTHROPIC_MODEL_NAME || 'claude-sonnet-4-5',
-      apiKey: process.env.ANTHROPIC_API_KEY,
-      temperature: 0.7,
-    });
-  } else {
-    // Use OpenAI (default)
-    llm = new ChatOpenAI({
-      modelName: process.env.OPENAI_MODEL_NAME || 'gpt-4.1-mini',
-      apiKey: process.env.OPENAI_API_KEY,
-      temperature: 0.7,
-    });
+  switch (provider) {
+    case 'anthropic':
+      // Use Anthropic Claude
+      llm = new ChatAnthropic({
+        modelName: process.env.ANTHROPIC_MODEL_NAME || 'claude-sonnet-4-5',
+        apiKey: process.env.ANTHROPIC_API_KEY,
+        temperature,
+      });
+      break;
+
+    case 'openai':
+    default:
+      // Use OpenAI (default)
+      llm = new ChatOpenAI({
+        modelName: process.env.OPENAI_MODEL_NAME || 'gpt-4.1-mini',
+        apiKey: process.env.OPENAI_API_KEY,
+        temperature,
+      });
+      break;
   }
 
   const structuredLLM = llm.withStructuredOutput(EngineEventPayloadSchema);

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,100 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
-npm install
-npm run build
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Create tmp directory and setup logging
+mkdir -p tmp
+LOG_FILE="tmp/startup.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+echo "=== Setup started at $(date) ===" >> "$LOG_FILE"
+echo -e "${GREEN}=== SynchronicityEngine Setup ===${NC}"
+echo -e "${YELLOW}Logging to: $LOG_FILE${NC}\n"
+
+# Install dependencies
+echo -e "${YELLOW}Installing dependencies...${NC}"
+if npm install; then
+    echo -e "${GREEN}✓ Dependencies installed${NC}\n"
+else
+    echo -e "${RED}✗ Failed to install dependencies${NC}"
+    read -p "Press Enter to close..."
+    exit 1
+fi
+
+# Build all packages
+echo -e "${YELLOW}Building all packages...${NC}"
+if npm run build; then
+    echo -e "${GREEN}✓ Build successful${NC}\n"
+else
+    echo -e "${RED}✗ Build failed${NC}"
+    read -p "Press Enter to close..."
+    exit 1
+fi
+
+# Start Docker services
+echo -e "${YELLOW}Starting Docker services...${NC}"
+if ! command -v docker &> /dev/null; then
+    echo -e "${RED}✗ Docker not found. Please install Docker Desktop.${NC}"
+    read -p "Press Enter to close..."
+    exit 1
+fi
+
+if ! docker info &> /dev/null; then
+    echo -e "${RED}✗ Docker is not running. Please start Docker Desktop.${NC}"
+    read -p "Press Enter to close..."
+    exit 1
+fi
+
+if docker compose up -d; then
+    echo -e "${GREEN}✓ Docker services started${NC}"
+    echo -e "${YELLOW}Waiting for database to be ready...${NC}"
+
+    # Wait for database to be healthy
+    for i in {1..30}; do
+        if docker compose exec -T postgres pg_isready -U synchronicity &> /dev/null; then
+            echo -e "${GREEN}✓ Database is ready${NC}\n"
+            break
+        fi
+        if [ $i -eq 30 ]; then
+            echo -e "${RED}✗ Database failed to start${NC}"
+            read -p "Press Enter to close..."
+            exit 1
+        fi
+        sleep 1
+    done
+else
+    echo -e "${RED}✗ Failed to start Docker services${NC}"
+    read -p "Press Enter to close..."
+    exit 1
+fi
+
+# Run database migrations
+echo -e "${YELLOW}Running database migrations...${NC}"
+if npm run migrate --workspace=@synchronicity/persistence; then
+    echo -e "${GREEN}✓ Migrations completed${NC}\n"
+else
+    echo -e "${RED}✗ Migrations failed${NC}"
+    read -p "Press Enter to close..."
+    exit 1
+fi
+
+# Success - start dev servers automatically
+echo -e "${GREEN}=== Setup Complete! ===${NC}\n"
+echo -e "${YELLOW}Starting dev servers...${NC}"
+echo -e "${YELLOW}Backend will run on http://localhost:3000${NC}"
+echo -e "${YELLOW}Frontend will run on http://localhost:5173${NC}"
+echo -e "${YELLOW}Press Ctrl+C to stop both servers${NC}\n"
+
+# Start backend in background
+(cd apps/backend && npm run dev) &
+BACKEND_PID=$!
+
+# Start frontend (this will keep terminal open)
+(cd apps/frontend && npm run dev)
+
+# If frontend exits, kill backend
+kill $BACKEND_PID 2>/dev/null

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,6 +7,13 @@ RED='\033[0;31m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
+# DRY error handling helper
+fail_and_wait() {
+    echo -e "\n${RED}✗ $1${NC}"
+    read -p "Press Enter to close..."
+    exit 1
+}
+
 # Create tmp directory and setup logging
 mkdir -p tmp
 LOG_FILE="tmp/startup.log"
@@ -18,70 +25,53 @@ echo -e "${YELLOW}Logging to: $LOG_FILE${NC}\n"
 
 # Install dependencies
 echo -e "${YELLOW}Installing dependencies...${NC}"
-if npm install; then
-    echo -e "${GREEN}✓ Dependencies installed${NC}\n"
-else
-    echo -e "${RED}✗ Failed to install dependencies${NC}"
-    read -p "Press Enter to close..."
-    exit 1
+if ! npm install; then
+    fail_and_wait "Failed to install dependencies"
 fi
+echo -e "${GREEN}✓ Dependencies installed${NC}\n"
 
 # Build all packages
 echo -e "${YELLOW}Building all packages...${NC}"
-if npm run build; then
-    echo -e "${GREEN}✓ Build successful${NC}\n"
-else
-    echo -e "${RED}✗ Build failed${NC}"
-    read -p "Press Enter to close..."
-    exit 1
+if ! npm run build; then
+    fail_and_wait "Build failed"
 fi
+echo -e "${GREEN}✓ Build successful${NC}\n"
 
 # Start Docker services
 echo -e "${YELLOW}Starting Docker services...${NC}"
 if ! command -v docker &> /dev/null; then
-    echo -e "${RED}✗ Docker not found. Please install Docker Desktop.${NC}"
-    read -p "Press Enter to close..."
-    exit 1
+    fail_and_wait "Docker not found. Please install Docker Desktop."
 fi
 
 if ! docker info &> /dev/null; then
-    echo -e "${RED}✗ Docker is not running. Please start Docker Desktop.${NC}"
-    read -p "Press Enter to close..."
-    exit 1
+    fail_and_wait "Docker is not running. Please start Docker Desktop."
 fi
 
-if docker compose up -d; then
-    echo -e "${GREEN}✓ Docker services started${NC}"
-    echo -e "${YELLOW}Waiting for database to be ready...${NC}"
-
-    # Wait for database to be healthy
-    for i in {1..30}; do
-        if docker compose exec -T postgres pg_isready -U synchronicity &> /dev/null; then
-            echo -e "${GREEN}✓ Database is ready${NC}\n"
-            break
-        fi
-        if [ $i -eq 30 ]; then
-            echo -e "${RED}✗ Database failed to start${NC}"
-            read -p "Press Enter to close..."
-            exit 1
-        fi
-        sleep 1
-    done
-else
-    echo -e "${RED}✗ Failed to start Docker services${NC}"
-    read -p "Press Enter to close..."
-    exit 1
+if ! docker compose up -d; then
+    fail_and_wait "Failed to start Docker services"
 fi
+
+echo -e "${GREEN}✓ Docker services started${NC}"
+echo -e "${YELLOW}Waiting for database to be ready...${NC}"
+
+# Wait for database to be healthy
+for i in {1..30}; do
+    if docker compose exec -T postgres pg_isready -U synchronicity &> /dev/null; then
+        echo -e "${GREEN}✓ Database is ready${NC}\n"
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        fail_and_wait "Database failed to start"
+    fi
+    sleep 1
+done
 
 # Run database migrations
 echo -e "${YELLOW}Running database migrations...${NC}"
-if npm run migrate --workspace=@synchronicity/persistence; then
-    echo -e "${GREEN}✓ Migrations completed${NC}\n"
-else
-    echo -e "${RED}✗ Migrations failed${NC}"
-    read -p "Press Enter to close..."
-    exit 1
+if ! npm run migrate --workspace=@synchronicity/persistence; then
+    fail_and_wait "Migrations failed"
 fi
+echo -e "${GREEN}✓ Migrations completed${NC}\n"
 
 # Success - start dev servers automatically
 echo -e "${GREEN}=== Setup Complete! ===${NC}\n"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Colors for output
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary
- Added Docker Compose setup with PostgreSQL on port 5436
- Enhanced startup script with auto-start, logging, and error handling
- Added Anthropic Claude support alongside OpenAI
- Fixed .env loading across persistence package
- Updated to latest LLM models (GPT-4.1-mini, Claude Sonnet 4.5)

## Changes

### Docker & Database
- ✅ Add `docker-compose.yml` with PostgreSQL 16 on port 5436 (avoiding conflicts)
- ✅ Fix `.env` loading in `migrate.ts`, `seed.ts`, and `db.ts` to use project root
- ✅ Update `.gitignore` to exclude `tmp/` logs
- ✅ Remove obsolete `version` attribute from docker-compose

### Setup Script Improvements
- ✅ Enhanced `scripts/setup.sh` with colored output and clear error messages
- ✅ Auto-start Docker Compose and wait for database health
- ✅ Run migrations automatically after database is ready
- ✅ Auto-start both dev servers (backend + frontend)
- ✅ Log all output to `tmp/startup.log` for debugging

### LLM Provider Updates
- ✅ Add Anthropic Claude support to `LangChainAdapter`
- ✅ Install `@langchain/anthropic` package
- ✅ Support `LANGCHAIN_PROVIDER` env variable (openai/anthropic)
- ✅ Add `ANTHROPIC_MODEL_NAME` configuration
- ✅ Update to latest OpenAI models (gpt-4.1-mini, gpt-4.1-nano, gpt-4.1)
- ✅ Update `.env.example` with new model options and descriptions

## Configuration

### Anthropic (Claude)
```bash
LLM_PROVIDER=langchain
LANGCHAIN_PROVIDER=anthropic
ANTHROPIC_MODEL_NAME=claude-sonnet-4-5  # or claude-haiku-4-5, claude-opus-4-1
```

### OpenAI (Latest GPT-4.1)
```bash
LLM_PROVIDER=openai
OPENAI_MODEL_NAME=gpt-4.1-mini  # or gpt-4.1-nano, gpt-4.1
```

## Testing
- ✅ Migrations run successfully
- ✅ All 12 database tables created
- ✅ Docker starts and health checks pass
- ✅ Setup script completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)